### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Second of all, you need to install below in advance.
   - **phis**
     - phis is a function that enable to select a command that was executed in the past
   - **pk**
-    - pk is a function that kill selected processes
+    - pk is a function that kill or just output selected processes
   - **pt**
     - pt is a function that can be attached to tmux session
 - other functions

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ readonly DIR=$(cd $(dirname $0)/tools; pwd)
 COMMAND_FILES="$DIR/_echo "
 COMMAND_FILES+="$DIR/_exec-command "
 COMMAND_FILES+="$DIR/_insert-command "
+COMMAND_FILES+="$DIR/_print-error-message "
 COMMAND_FILES+="$DIR/_write-stderror "
 COMMAND_FILES+="$DIR/show256 "
 COMMAND_FILES+="$DIR/google "

--- a/tools/_print-error-message
+++ b/tools/_print-error-message
@@ -1,0 +1,3 @@
+# !/bin/zsh -e
+
+_write-stderror "Canceled or something went wrong"

--- a/tools/peco-commands/gcd
+++ b/tools/peco-commands/gcd
@@ -10,12 +10,8 @@ function gcd() {
 
     # move to the selected git project
     if [ ${#_context_path} -eq 0 ]; then
-        if zle; then
-            :
-        else
-            echo "Canceled or something went wrong" >&2
-            return 1
-        fi
+        _print-error-message
+		return 1
     else
         # target git project directory path
         _exec-command "cd $_project_path"

--- a/tools/peco-commands/gg
+++ b/tools/peco-commands/gg
@@ -26,7 +26,7 @@ function gg() {
 
     # slect a condition from the menu and execute the action
     if [ $SELECTED_FILES_NUM -eq 0 ]; then
-        echo "Did not hit or canceled" >&2
+        _write-stderror "Did not hit or canceled"
         return 1
     elif [ $SELECTED_FILES_NUM -gt 1 ] && [ $UNIQUED_FILES_NUM -gt 1 ]; then
         action="`echo -e "${actions[view]}\n${actions[edit-buffer]}" | peco --prompt "${prompts[act]}"`"
@@ -37,7 +37,7 @@ function gg() {
             echo "$action on $UNIQUED_FILES"
             eval bat $UNIQUED_FILES
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     elif [ $SELECTED_FILES_NUM -gt 1 ] && [ $UNIQUED_FILES_NUM -eq 1 ]; then
@@ -49,7 +49,7 @@ function gg() {
             echo "$action on $UNIQUED_FILES"
             eval bat $UNIQUED_FILES
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     else
@@ -61,7 +61,7 @@ function gg() {
             echo "$action on $UNIQUED_FILES"
             eval bat $UNIQUED_FILES
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     fi

--- a/tools/peco-commands/pbr
+++ b/tools/peco-commands/pbr
@@ -24,7 +24,7 @@ function pbr() {
 
     # select a condition from the menu and execute the action
     if [ ${#TARGET_BRANCH} -eq 0 ]; then
-        echo "Did not hit or canceled" >&2
+        _write-stderror "Did not hit or canceled"
         return 1
     elif [ $BRANCH_NUM -gt 1 ]; then
         action="`echo -e "${actions[delete]}\n${actions[delete-force]}" | peco --prompt "${prompts[act]}"`"
@@ -35,7 +35,7 @@ function pbr() {
             echo "$action on $TARGET_BRANCH"
             eval git branch -D $TARGET_BRANCH
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     else
@@ -50,7 +50,7 @@ function pbr() {
             echo "$action on $TARGET_BRANCH"
             eval git branch -D $TARGET_BRANCH
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     fi

--- a/tools/peco-commands/pcd
+++ b/tools/peco-commands/pcd
@@ -6,7 +6,7 @@
 function pcd() {
     local _target_dir="$(ls -al | grep -E "^d" | peco --prompt "movet to>" | awk "{print \$9}")"
     if [ ${#_target_dir} -eq 0 ]; then
-        echo "Canceled or something went wrong" >&2
+        _print-error-message
         return 1
     else
         _exec-command "cd $_target_dir"

--- a/tools/peco-commands/pcdr
+++ b/tools/peco-commands/pcdr
@@ -6,12 +6,8 @@
 function pcdr() {
     local _target_dir="$(cdr -l | peco --prompt "cdr>" | awk '{print $2}')"
     if [ ${#_target_dir} -eq 0 ]; then
-        if zle; then
-            :
-        else
-            echo "Canceled or something went wrong" >&2
-            return 1
-        fi
+        _print-error-message
+        return 1
     else
         _exec-command "cd ${_target_dir}"
     fi

--- a/tools/peco-commands/pco
+++ b/tools/peco-commands/pco
@@ -8,7 +8,7 @@ function pco() {
 
     # select a condition from the menu and execute the action
     if [ -z $_target_branch ]; then
-        echo "Canceled or something went wrong" >&2
+        _print-error-message
         return 1
     else
         git checkout $_target_branch

--- a/tools/peco-commands/pe
+++ b/tools/peco-commands/pe
@@ -5,10 +5,15 @@
 #
 function pe() {
     local _target_container="$(docker ps | peco --prompt "docker container>" | cut -d " " -f 1)"
-    if [ ${#_target_container} -eq 0 ]; then
+    local _selected_num=`echo $_target_container | wc -w`
+    if [ ${#_target_container} -eq 0 ] || [ ${_target_container} = "CONTAINER" ]; then
         _print-error-message
         return 1
+    elif [ $_selected_num -gt 1 ]; then
+        _write-stderror "You can choose just one container"
+		return 1
     else
         _insert-command "docker exec -it $_target_container /bin/bash"
     fi
 }
+

--- a/tools/peco-commands/pe
+++ b/tools/peco-commands/pe
@@ -6,7 +6,7 @@
 function pe() {
     local _target_container="$(docker ps | peco --prompt "docker container>" | cut -d " " -f 1)"
     if [ ${#_target_container} -eq 0 ]; then
-        echo "Canceled or something went wrong" >&2
+        _print-error-message
         return 1
     else
         _insert-command "docker exec -it $_target_container /bin/bash"

--- a/tools/peco-commands/pf
+++ b/tools/peco-commands/pf
@@ -38,7 +38,7 @@ function pff() {
     local _selected_files=`find . -type f | peco --prompt "${prompts[pff]}" | tr "\n" " "`
     local _selected_files_num=`echo $_selected_files | wc -w`
     if [ $_selected_files_num -eq 0 ]; then
-        echo "Did not hit or canceled" >&2
+        _write-stderror "Did not hit or canceled"
         return 1
     elif [ $_selected_files_num -gt 1 ]; then
         action="`echo -e "${actions[view]}\n${actions[edit-buffer]}" | peco --prompt "${prompts[act]}"`"
@@ -49,8 +49,7 @@ function pff() {
             echo "$action on $_selected_files"
             eval bat $_selected_files
         else
-            echo "Canceled or something went wrong" >&2
-        return 1
+            _print-error-message
             return 1
         fi
     else
@@ -62,7 +61,7 @@ function pff() {
             echo "$action on $_selected_files"
             eval bat $_selected_files
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     fi
@@ -73,10 +72,10 @@ function pfd() {
     local _selected_directories=`find . -type d | peco --prompt "${prompts[pfd]}" | tr "\n" " "`
     local _selected_directories_num=`echo $_selected_directories | wc -w`
     if [ $_selected_directories_num -eq 0 ]; then
-        echo "Did not hit or canceled" >&2
+        _write-stderror "Did not hit or canceled"
         return 1
     elif [ $_selected_directories_num -gt 1 ]; then
-        echo "You can choose just one directory" >&2
+        _write-stderror "You can choose just one directory"
         return 1
     else
         action="`echo -e "${actions[list]}\n${actions[change-dir]}" | peco --prompt "${prompts[act]}"`"
@@ -87,7 +86,7 @@ function pfd() {
             echo "$action on $_selected_directories"
             _exec-command "cd $_selected_directories"
         else
-            echo "Canceled or something went wrong" >&2
+            _print-error-message
             return 1
         fi
     fi
@@ -113,3 +112,4 @@ else
         return 1
     fi
 fi
+

--- a/tools/peco-commands/pgl
+++ b/tools/peco-commands/pgl
@@ -4,81 +4,81 @@
 # pgl is a function that enable to show git log and do several actions on selected commit
 #
 function pgl() {
-	# actions on target commit
-	typeset -A actions
-	actions=(
-		output     ">> output"
-		pbcopy     ">> pbcopy"
-		show       ">> show"
-		checkout   ">> checkout"
-		cherrypick ">> cherry-pick"
-		resethard  ">> reset-hard"
-	)
-	# prompt of peco
-	typeset -A prompts
-	prompts=(
-		gl    "git log>"
-		act   "choose action>"
-	)
-	# select commit with peco
-	readonly _target_commit=$(git log --graph --all --pretty=format:'%x09%C(yellow)%h %C(red)[%ad]%C(auto)%d %C(white)%s' --date=format:'%Y/%m/%d %H:%M:%S' | peco --prompt "${prompts[gl]}" | sed -E "s/[\|\*\\ \/]+//" | sed "/^$/d")
-	readonly _commit_id=$(echo $_target_commit | awk '{print $1}')
-	readonly _trimmed_line_commit_id=$(echo $_commit_id | tr "\n" " ")
-	readonly _selected_num=`echo $_trimmed_line_commit_id | wc -w`
+    # actions on target commit
+    typeset -A actions
+    actions=(
+        output     ">> output"
+        pbcopy     ">> pbcopy"
+        show       ">> show"
+        checkout   ">> checkout"
+        cherrypick ">> cherry-pick"
+        resethard  ">> reset-hard"
+    )
+    # prompt of peco
+    typeset -A prompts
+    prompts=(
+        gl    "git log>"
+        act   "choose action>"
+    )
+    # select commit with peco
+    readonly _target_commit=$(git log --graph --all --pretty=format:'%x09%C(yellow)%h %C(red)[%ad]%C(auto)%d %C(white)%s' --date=format:'%Y/%m/%d %H:%M:%S' | peco --prompt "${prompts[gl]}" | sed -E "s/[\|\*\\ \/]+//" | sed "/^$/d")
+    readonly _commit_id=$(echo $_target_commit | awk '{print $1}')
+    readonly _trimmed_line_commit_id=$(echo $_commit_id | tr "\n" " ")
+    readonly _selected_num=`echo $_trimmed_line_commit_id | wc -w`
 
     # select a condition from the menu and execute the action
     if [ $_selected_num -eq 1 ]; then
-		action=`echo -e "${actions[output]}\n${actions[pbcopy]}\n${actions[show]}\n${actions[checkout]}\n${actions[cherrypick]}\n${actions[resethard]}" | peco --prompt "${prompts[act]}"`
-		if [[ "$action" = "${actions[output]}" ]]; then
-			_exec-command "echo $_commit_id"
-		elif [[ "$action" = "${actions[pbcopy]}" ]]; then
-			_echo "$action on $_trimmed_line_commit_id"
-			_exec-command "echo $_commit_id | pbcopy"
-		elif [[ "$action" = "${actions[checkout]}" ]]; then
-			_echo "$action on $_trimmed_line_commit_id"
-			_exec-command "git checkout $_trimmed_line_commit_id"
-		elif [[ "$action" = "${actions[show]}" ]]; then
-			_echo "$action on $_trimmed_line_commit_id"
-			_exec-command "git show $_trimmed_line_commit_id"
-		elif [[ "$action" = "${actions[cherrypick]}" ]]; then
-			_echo "$action on $_trimmed_line_commit_id"
-			_exec-command "git cherry-pick $_trimmed_line_commit_id"
-		elif [[ "$action" = "${actions[resethard]}" ]]; then
-			if zle; then
-				_insert-command "git reset --hard $_trimmed_line_commit_id"
-			else
-				echo "$action on $_trimmed_line_commit_id"
-				printf "Are you sure? [y/n] > "
-				if read -q; then
-					echo ""
-					eval git reset --hard $_trimmed_line_commit_id
-				else
-					return 0
-				fi
-			fi
-		else
-			_print-error-message
-			return 1
-		fi
-	elif [ $_selected_num -gt 1 ]; then
-		action=`echo -e "${actions[output]}\n${actions[pbcopy]}" | peco --prompt "${prompts[act]}"`
-		if [[ "$action" = "${actions[output]}" ]]; then
-			if zle; then
-				_exec-command "echo $_trimmed_line_commit_id"
-			else
-				echo $_commit_id
-			fi
-		elif [[ "$action" = "${actions[pbcopy]}" ]]; then
-			if zle; then
-				_exec-command "echo $_trimmed_line_commit_id | pbcopy"
-			else
-				echo "$action on $_trimmed_line_commit_id"
-				echo $_commit_id | pbcopy
-			fi
-		else
-			_print-error-message
-			return 1
-		fi
+        action=`echo -e "${actions[output]}\n${actions[pbcopy]}\n${actions[show]}\n${actions[checkout]}\n${actions[cherrypick]}\n${actions[resethard]}" | peco --prompt "${prompts[act]}"`
+        if [[ "$action" = "${actions[output]}" ]]; then
+            _exec-command "echo $_commit_id"
+        elif [[ "$action" = "${actions[pbcopy]}" ]]; then
+            _echo "$action on $_trimmed_line_commit_id"
+            _exec-command "echo $_commit_id | pbcopy"
+        elif [[ "$action" = "${actions[checkout]}" ]]; then
+            _echo "$action on $_trimmed_line_commit_id"
+            _exec-command "git checkout $_trimmed_line_commit_id"
+        elif [[ "$action" = "${actions[show]}" ]]; then
+            _echo "$action on $_trimmed_line_commit_id"
+            _exec-command "git show $_trimmed_line_commit_id"
+        elif [[ "$action" = "${actions[cherrypick]}" ]]; then
+            _echo "$action on $_trimmed_line_commit_id"
+            _exec-command "git cherry-pick $_trimmed_line_commit_id"
+        elif [[ "$action" = "${actions[resethard]}" ]]; then
+            if zle; then
+                _insert-command "git reset --hard $_trimmed_line_commit_id"
+            else
+                echo "$action on $_trimmed_line_commit_id"
+                printf "Are you sure? [y/n] > "
+                if read -q; then
+                    echo ""
+                    eval git reset --hard $_trimmed_line_commit_id
+                else
+                    return 0
+                fi
+            fi
+        else
+            _print-error-message
+            return 1
+        fi
+    elif [ $_selected_num -gt 1 ]; then
+        action=`echo -e "${actions[output]}\n${actions[pbcopy]}" | peco --prompt "${prompts[act]}"`
+        if [[ "$action" = "${actions[output]}" ]]; then
+            if zle; then
+                _exec-command "echo $_trimmed_line_commit_id"
+            else
+                echo $_commit_id
+            fi
+        elif [[ "$action" = "${actions[pbcopy]}" ]]; then
+            if zle; then
+                _exec-command "echo $_trimmed_line_commit_id | pbcopy"
+            else
+                echo "$action on $_trimmed_line_commit_id"
+                echo $_commit_id | pbcopy
+            fi
+        else
+            _print-error-message
+            return 1
+        fi
     else
         _print-error-message
         return 1

--- a/tools/peco-commands/pgl
+++ b/tools/peco-commands/pgl
@@ -84,7 +84,3 @@ function pgl() {
         return 1
     fi
 }
-
-function _print-error-message() {
-	_write-stderror "Canceled or something went wrong"
-}

--- a/tools/peco-commands/phis
+++ b/tools/peco-commands/phis
@@ -6,12 +6,8 @@
 function phis() {
     local _target_command=$(history -n -r 1 | peco --prompt "history>" --query "$LBUFFER")
     if [ ${#_target_command} -eq 0 ]; then
-        if zle; then
-            :
-        else
-            echo "Canceled or something went wrong" >&2
-            return 1
-        fi
+        _print-error-message
+        return 1
     else
         _insert-command $_target_command
     fi

--- a/tools/peco-commands/pk
+++ b/tools/peco-commands/pk
@@ -1,12 +1,52 @@
 #!/bin/zsh -e
 
 #
-# pk is a function that kill selected processes
+# pk is a function that kill selected processes or just output selected pids
 #
 function pk() {
-    for pid in `ps aux | peco --prompt "pkill>" | awk '{ print $2 }'`
-    do
-        kill $pid
-        echo "Killd ${pid}"
-    done
+    # actions on target pid
+    typeset -A actions
+    actions=(
+        output    ">> output"
+        kill     ">> kill"
+    )
+    # prompt of peco
+    typeset -A prompts
+    prompts=(
+        pk    "processes>"
+        act   "choose action>"
+    )
+
+    # selected pids
+    readonly _pids=`ps aux | peco --prompt "${prompts[pk]}" | awk '{ print $2 }'`
+    readonly _selected_num=`echo $_pids | wc -w`
+    if [ $_selected_num -eq 0 ]; then
+        _write-stderror "Did not hit or canceled"
+        return 1
+    else
+        action=`echo -e "${actions[output]}\n${actions[kill]}" | peco --prompt "${prompts[act]}"`
+        if [ "$action" = "${actions[output]}" ]; then
+            echo $_pids
+        elif [ "$action" = "${actions[kill]}" ]; then
+            target_pids=`echo $_pids | tr "\n" " "`
+            echo "$action on $target_pids"
+            for pid in `echo $target_pids`
+            do
+                _kill ${pid}
+            done
+        else
+            _print-error-message
+            return 1
+        fi
+    fi
 }
+
+function _kill() {
+    if [ $1 = "PID" ]; then
+        echo "skipped header line"
+    else
+        kill $1
+        echo "Killed: pid=$1"
+    fi
+}
+

--- a/tools/peco-commands/pt
+++ b/tools/peco-commands/pt
@@ -9,7 +9,7 @@ function pt() {
     local _options="${_new_session}\n${_sessions}"
     local _selected_session="$(echo -e "$_options" | peco --prompt "tmux session>" | cut -d: -f1)"
     if [ -z $_selected_session ]; then
-        echo "Canceled or something went wrong" >&2
+        _print-error-message
         return 1
     elif [ $_selected_session = "$_new_session" ]; then
         tmux new-session


### PR DESCRIPTION
* Extracted the local function _print-error-message to be enable to be referenced from other commands
* Changed to use the function _print-error-message in gcd command
* Changed to use the function _print-error-message in pco command
* Changed to use the function _print-error-message in pe command
* Changed to use the function _print-error-message in pcdr command
* Changed to use the function _print-error-message in gg command
* Changed to use the function _print-error-message in pt command
* Changed to use the function _print-error-message in pcd command
* Changed to use the function _print-error-message in phis command
* Changed to use the function _print-error-message in pf command
* Changed to use the function _print-error-message in pbr command
* Converted tabs to 4 spaces in pgl
* Improved pe command not to be unable to select header line
* Improved pk command to be a safer command
